### PR TITLE
Align sms maintenance baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
+  MISE_JOBS: 1
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          install: true
+
+      - name: Check whitespace
+        run: git diff --check
+
+      - name: Run tests
+        run: mise run test
+
+      - name: Run codebase lints
+        run: codebase lint "$PWD"
+
+      - name: Check README.md is up to date
+        uses: KnickKnackLabs/readme@v0.3.1
+        with:
+          check: true

--- a/.mise/tasks/read
+++ b/.mise/tasks/read
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 #MISE description="Read recent SMS messages"
 #USAGE flag "--limit <limit>" default="20" help="Maximum number of messages to retrieve"
-#USAGE flag "--json" help="Output as JSON"
+#USAGE flag "--json" default=#false help="Output as JSON"
 # /// script
 # dependencies = ["slixmpp>=1.8"]
 # ///

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS tests"
+#MISE dir="{{config_root}}"
+#USAGE arg "[args]" default="" var=#true help="Test suites or bats arguments"
+#USAGE example "mise run test" header="Run all tests"
+#USAGE example "mise run test sms" header="Run a specific suite by name"
+#USAGE example "mise run test --filter credentials" header="Filter tests by name"
 set -euo pipefail
 
-cd "$MISE_CONFIG_ROOT"
-bats test/
+TEST_DIR="$MISE_CONFIG_ROOT/test"
+
+args=()
+if [ -n "${usage_args:-}" ]; then
+  while IFS= read -r arg; do
+    [ -z "$arg" ] && continue
+    args+=("$arg")
+  done < <(printf '%s' "${usage_args}" | xargs printf '%s\n')
+fi
+
+resolved=()
+has_target=false
+
+for arg in ${args[@]+"${args[@]}"}; do
+  if [[ "$arg" != -* && "$arg" != *.bats && -f "$TEST_DIR/$arg.bats" ]]; then
+    resolved+=("$TEST_DIR/$arg.bats")
+    has_target=true
+  else
+    [[ "$arg" == *.bats || -d "$arg" ]] && has_target=true
+    resolved+=("$arg")
+  fi
+done
+
+if ! $has_target; then
+  resolved+=("$TEST_DIR/")
+fi
+
+exec bats --print-output-on-failure "${resolved[@]}"

--- a/.mise/tasks/wait
+++ b/.mise/tasks/wait
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run --script
 #MISE description="Wait for a new SMS message"
-#USAGE flag "--from <from>" help="Only wait for messages from this number"
+#USAGE flag "--from <from>" default="" help="Only wait for messages from this number"
 #USAGE flag "--timeout <timeout>" default="300" help="Seconds to wait before giving up (default 5 minutes)"
-#USAGE flag "--json" help="Output as JSON"
+#USAGE flag "--json" default=#false help="Output as JSON"
 # /// script
 # dependencies = ["slixmpp>=1.8"]
 # ///

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+`sms` gives agents an SMS-capable XMPP client through JMP.chat. Keep infrastructure changes boring and preserve the live-network boundary: tests and CI must not require real SMS credentials or external XMPP accounts unless a task explicitly documents that it is an integration test.
+
+## Structure
+
+```text
+sms/
+├── mise.toml              # tools, settings, and codebase lint config
+├── README.tsx             # source for generated README.md
+├── README.md              # generated; keep in sync with README.tsx
+├── CONTRIBUTING.md        # repo orientation surface
+├── lib/xmpp.py            # shared async XMPP/SMS client logic
+├── .mise/tasks/           # user-facing sms commands
+└── test/                  # BATS tests and helpers
+```
+
+## Local setup
+
+```bash
+mise trust
+mise install
+mise run test
+```
+
+For live SMS checks, set credentials in the environment first:
+
+```bash
+export SMS_JID="agent@xmpp.chat"
+export SMS_PASSWORD="..."
+mise run welcome
+```
+
+Do not commit credentials, phone-number routing changes, payment setup, or account-provisioning side effects.
+
+## Task conventions
+
+- Use mise file tasks with `#MISE description`.
+- Use `#USAGE` for task arguments and flags.
+- Give optional `#USAGE` values explicit defaults so stale inherited `usage_*` environment cannot change behavior.
+- Keep network/XMPP logic in `lib/xmpp.py`; task files should stay thin CLI wrappers.
+- Python task files may use `uv run --script` with PEP 723 dependencies; shared imports should go through `MISE_CONFIG_ROOT/lib`.
+
+## Test conventions
+
+- BATS tests should call tasks through `mise run`, via `test/test_helper.bash`.
+- The default test suite must not need live XMPP credentials.
+- Prefer pure helper tests or mocked boundaries for behavior that does not need a real server.
+- Use a separate, explicit integration-test path before adding local XMPP server coverage.
+
+## README workflow
+
+Edit `README.tsx`, then regenerate and check the output:
+
+```bash
+readme build
+readme build --check
+```
+
+CI also checks that `README.md` matches `README.tsx`.
+
+## Validation before merge
+
+```bash
+mise run test
+codebase lint "$PWD"
+readme build --check
+git diff --check
+```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Send and receive SMS through [JMP.chat](https://jmp.chat), which bridges SMS to 
 ![protocol: XMPP](https://img.shields.io/badge/protocol-XMPP-blue?style=flat)
 [![bridge: JMP.chat](https://img.shields.io/badge/bridge-JMP.chat-7c3aed?style=flat)](https://jmp.chat)
 [![library: slixmpp](https://img.shields.io/badge/library-slixmpp-3776AB?style=flat&logo=python&logoColor=white)](https://slixmpp.readthedocs.io)
-![tests: 3 passing](https://img.shields.io/badge/tests-3%20passing-brightgreen?style=flat)
+![tests: 4 passing](https://img.shields.io/badge/tests-4%20passing-brightgreen?style=flat)
+![lints: 9](https://img.shields.io/badge/lints-9-blue?style=flat)
+![README: TSX](https://img.shields.io/badge/README-TSX-f472b6?style=flat)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
 
@@ -78,8 +81,6 @@ sms wait --from +15551234567                 # block until reply
 | SMS / MMS       |   | SMS ↔ XMPP   |   | slixmpp     |
 | phone number    |   | $3.79/month  |   | MAM archive |
 | carrier network |   | cheogram bot |   | mise tasks  |
-|                 |   |              |   |             |
-|                 |   |              |   |             |
 +-----------------+   +--------------+   +-------------+
 </pre>
 
@@ -98,18 +99,18 @@ JMP treats phone numbers as person-to-person, which sidesteps 10DLC registration
 
 ## Commands
 
-| Command | Description |
-| --- | --- |
-| `sms archive:enable` | Enable MAM (Message Archive Management) on the XMPP account |
-| `sms archive:status` | Check MAM (Message Archive Management) status |
-| `sms contact:add <jid>` | Add a contact to the XMPP roster |
-| `sms contact:list` | List contacts in the XMPP roster |
-| `sms listen --timeout <timeout>` | Listen for incoming messages in real-time |
-| `sms read --limit <limit> --json` | Read recent SMS messages |
-| `sms send <destination> <message>` | Send an SMS message |
-| `sms test` | Run BATS tests |
-| `sms wait --from <from> --timeout <timeout> --json` | Wait for a new SMS message |
-| `sms welcome` | Check SMS connectivity and account status |
+| Command                                             | Description                                                 |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| `sms archive:enable`                                | Enable MAM (Message Archive Management) on the XMPP account |
+| `sms archive:status`                                | Check MAM (Message Archive Management) status               |
+| `sms contact:add <jid>`                             | Add a contact to the XMPP roster                            |
+| `sms contact:list`                                  | List contacts in the XMPP roster                            |
+| `sms listen --timeout <timeout>`                    | Listen for incoming messages in real-time                   |
+| `sms read --limit <limit> --json`                   | Read recent SMS messages                                    |
+| `sms send <destination> <message>`                  | Send an SMS message                                         |
+| `sms test [args]`                                   | Run BATS tests                                              |
+| `sms wait --from <from> --timeout <timeout> --json` | Wait for a new SMS message                                  |
+| `sms welcome`                                       | Check SMS connectivity and account status                   |
 
 <br />
 
@@ -166,11 +167,16 @@ Getting a number takes about 10 minutes:
 
 ```bash
 gh repo clone KnickKnackLabs/sms
-cd sms && mise trust && mise install
+cd sms
+mise trust
+mise install
 mise run test
+codebase lint "$PWD"
+readme build --check
+git diff --check
 ```
 
-3 tests using [BATS](https://github.com/bats-core/bats-core). The test suite validates task structure and error handling without requiring live XMPP credentials.
+4 tests using [BATS](https://github.com/bats-core/bats-core). The default test suite validates task structure and error handling without requiring live XMPP credentials. See [CONTRIBUTING.md](CONTRIBUTING.md) for local workflow and live-network boundaries.
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -127,6 +127,9 @@ const readme = (
         <Badge label="bridge" value="JMP.chat" color="7c3aed" href="https://jmp.chat" />
         <Badge label="library" value="slixmpp" color="3776AB" href="https://slixmpp.readthedocs.io" logo="python" logoColor="white" />
         <Badge label="tests" value={`${testCount} passing`} color="brightgreen" />
+        <Badge label="lints" value="9" color="blue" />
+        <Badge label="README" value="TSX" color="f472b6" />
+        <Badge label="License" value="MIT" color="blue" href="LICENSE" />
       </Badges>
     </Center>
 
@@ -254,13 +257,20 @@ echo "$response" | jq -r .body >> check-ins.log`}</CodeBlock>
 
     <Section title="Development">
       <CodeBlock lang="bash">{`gh repo clone KnickKnackLabs/sms
-cd sms && mise trust && mise install
-mise run test`}</CodeBlock>
+cd sms
+mise trust
+mise install
+mise run test
+codebase lint "$PWD"
+readme build --check
+git diff --check`}</CodeBlock>
 
       <Paragraph>
         {`${testCount} tests using `}
         <Link href="https://github.com/bats-core/bats-core">BATS</Link>
-        {". The test suite validates task structure and error handling without requiring live XMPP credentials."}
+        {". The default test suite validates task structure and error handling without requiring live XMPP credentials. See "}
+        <Link href="CONTRIBUTING.md">CONTRIBUTING.md</Link>
+        {" for local workflow and live-network boundaries."}
       </Paragraph>
     </Section>
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,27 @@
-[tools]
-python = "3"
-uv = "0.10.0"
-bats = "1.13.0"
-usage = "1"
-
 [settings]
 lockfile = true
 quiet = true
 task_output = "interleave"
+experimental = true
+
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
+
+[tools]
+uv = "0.10.0"
+bats = "1.13.0"
+"shiv:codebase" = "0.3"
+"shiv:readme" = "0.3"
+
+[_.codebase]
+lint = [
+  "mise-settings",
+  "bats-test-helper",
+  "bats-test-task",
+  "mcr-scope",
+  "or-true",
+  "shellcheck",
+  "gum-table",
+  "caller-pwd-contract",
+  "github-actions",
+]

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,8 @@
+setup_suite() {
+  REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_DIR
+
+  local bats_libexec="${BATS_LIBEXEC:-}"
+  eval "$(cd "$REPO_DIR" && mise env)"
+  [ -z "$bats_libexec" ] || export PATH="$bats_libexec:$PATH"
+}

--- a/test/sms.bats
+++ b/test/sms.bats
@@ -13,7 +13,7 @@ setup() {
 
 @test "send: fails without credentials" {
   unset SMS_JID SMS_PASSWORD
-  run sms send -- "+19195551234" "test"
+  run sms send "+19195551234" "test"
   [ "$status" -ne 0 ]
   [[ "$output" == *"SMS_JID and SMS_PASSWORD must be set"* ]]
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,11 +1,7 @@
-# Tests must be run via `mise run test`
-if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
-  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test" >&2
-  exit 1
-fi
+# Shared fixtures for sms tests.
 
+# Run a repo task through mise so tests exercise the real task path.
 sms() {
-  local subcmd="$1"; shift
-  cd "$MISE_CONFIG_ROOT" && mise run "$subcmd" -- "$@"
+  cd "$REPO_DIR" && mise run -q "$@"
 }
 export -f sms


### PR DESCRIPTION
## Summary

Bring `sms` closer to the current `KnickKnackLabs/template` maintenance baseline without changing live SMS/XMPP behavior.

- add Ubuntu/macOS CI with whitespace, tests, codebase lints, and README check
- declare repo-local `codebase` / `readme` tooling and lint rules
- add `CONTRIBUTING.md` with local workflow and live-network boundaries
- update the BATS test task/helper to the canonical targetable `mise run test` shape
- clear inherited optional `usage_*` env for `read --json`, `wait --from`, and `wait --json`
- regenerate README from `README.tsx` with current test count and validation commands

## Validation

- `bash -n .mise/tasks/test test/test_helper.bash`
- `python3 -m py_compile lib/xmpp.py .mise/tasks/archive/enable .mise/tasks/archive/status .mise/tasks/contact/add .mise/tasks/contact/list .mise/tasks/listen .mise/tasks/read .mise/tasks/send .mise/tasks/wait .mise/tasks/welcome`
- `mise run test sms`
- `mise run test`
- `mise run test --filter credentials`
- `codebase lint "$PWD"`
- `readme build --check`
- `git diff --check`
- fold direct `mise run git:pre-commit /Users/rikonor/desks/quick-sms-business-20260619214100/sms`

## Notes

The installed `git pre-commit` shim in this shell is misconfigured and looked for a fold module in an unrelated desk path, so I used this desk's fold module to run `git:pre-commit` directly. Direct pre-commit passed after staging.

No SMS credentials, accounts, payment setup, routing, or live XMPP behavior were changed.
