### PR TITLE
Add JSON output for sms listen

### DIFF
--- a/.mise/tasks/listen
+++ b/.mise/tasks/listen
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S uv run --script
 #MISE description="Listen for incoming messages in real-time"
 #USAGE flag "--timeout <timeout>" default="60" help="Seconds to listen before exiting (0 for indefinite)"
+#USAGE flag "--json" default=#false help="Output each message as one JSON object (JSON Lines)"
 # /// script
 # dependencies = ["slixmpp>=1.8"]
 # ///
@@ -10,6 +11,7 @@ import os
 import sys
 
 sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from output import format_json_line, format_listen_human, listen_event, utc_timestamp
 from xmpp import listen_messages
 
 jid = os.environ.get("SMS_JID", "")
@@ -20,12 +22,16 @@ if not jid or not password:
     sys.exit(1)
 
 timeout = int(os.environ.get("usage_timeout", "60"))
+as_json = os.environ.get("usage_json", "false") == "true"
+
 
 def on_message(msg):
-    ts = msg.get("timestamp", "")
-    prefix = f"[{ts}] " if ts else ""
-    print(f"{prefix}{msg['from']}")
-    print(f"  {msg['body']}")
-    print(flush=True)
+    timestamp = utc_timestamp() if as_json else None
+    event = listen_event(msg, timestamp=timestamp)
+    if as_json:
+        print(format_json_line(event), flush=True)
+    else:
+        print(format_listen_human(event), flush=True)
+
 
 asyncio.run(listen_messages(jid, password, callback=on_message, timeout=timeout))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Send and receive SMS through [JMP.chat](https://jmp.chat), which bridges SMS to 
 ![protocol: XMPP](https://img.shields.io/badge/protocol-XMPP-blue?style=flat)
 [![bridge: JMP.chat](https://img.shields.io/badge/bridge-JMP.chat-7c3aed?style=flat)](https://jmp.chat)
 [![library: slixmpp](https://img.shields.io/badge/library-slixmpp-3776AB?style=flat&logo=python&logoColor=white)](https://slixmpp.readthedocs.io)
-![tests: 4 passing](https://img.shields.io/badge/tests-4%20passing-brightgreen?style=flat)
+![tests: 6 passing](https://img.shields.io/badge/tests-6%20passing-brightgreen?style=flat)
 ![lints: 9](https://img.shields.io/badge/lints-9-blue?style=flat)
 ![README: TSX](https://img.shields.io/badge/README-TSX-f472b6?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
@@ -105,7 +105,7 @@ JMP treats phone numbers as person-to-person, which sidesteps 10DLC registration
 | `sms archive:status`                                | Check MAM (Message Archive Management) status               |
 | `sms contact:add <jid>`                             | Add a contact to the XMPP roster                            |
 | `sms contact:list`                                  | List contacts in the XMPP roster                            |
-| `sms listen --timeout <timeout>`                    | Listen for incoming messages in real-time                   |
+| `sms listen --timeout <timeout> --json`             | Listen for incoming messages in real-time                   |
 | `sms read --limit <limit> --json`                   | Read recent SMS messages                                    |
 | `sms send <destination> <message>`                  | Send an SMS message                                         |
 | `sms test [args]`                                   | Run BATS tests                                              |
@@ -135,7 +135,8 @@ sms send +15551234567 "Deploy failed on main — check run #4521"
 ### Stream
 
 ```bash
-sms listen --timeout 0  # incoming messages, indefinitely
+sms listen --timeout 0         # human-readable incoming messages, indefinitely
+sms listen --timeout 0 --json  # JSON Lines for agent/session monitors
 ```
 
 <br />
@@ -176,7 +177,7 @@ readme build --check
 git diff --check
 ```
 
-4 tests using [BATS](https://github.com/bats-core/bats-core). The default test suite validates task structure and error handling without requiring live XMPP credentials. See [CONTRIBUTING.md](CONTRIBUTING.md) for local workflow and live-network boundaries.
+6 tests using [BATS](https://github.com/bats-core/bats-core). The default test suite validates task structure and error handling without requiring live XMPP credentials. See [CONTRIBUTING.md](CONTRIBUTING.md) for local workflow and live-network boundaries.
 
 <br />
 

--- a/README.tsx
+++ b/README.tsx
@@ -223,7 +223,8 @@ echo "$response" | jq -r .body >> check-ins.log`}</CodeBlock>
       </Section>
 
       <Section title="Stream" level={3}>
-        <CodeBlock lang="bash">{`sms listen --timeout 0  # incoming messages, indefinitely`}</CodeBlock>
+        <CodeBlock lang="bash">{`sms listen --timeout 0         # human-readable incoming messages, indefinitely
+sms listen --timeout 0 --json  # JSON Lines for agent/session monitors`}</CodeBlock>
       </Section>
     </Section>
 

--- a/lib/output.py
+++ b/lib/output.py
@@ -1,0 +1,33 @@
+"""Output formatting helpers for sms tasks."""
+
+import json
+from datetime import datetime, timezone
+
+
+def utc_timestamp():
+    """Return the current UTC timestamp for live message events."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def listen_event(message, timestamp=None):
+    """Normalize a live listen message into a serializable event."""
+    event = {
+        "from": str(message["from"]),
+        "to": str(message["to"]),
+        "body": str(message["body"]),
+    }
+    if timestamp is not None:
+        event["timestamp"] = timestamp
+    return event
+
+
+def format_listen_human(event):
+    """Format a listen event for human-readable terminal output."""
+    ts = event.get("timestamp", "")
+    prefix = f"[{ts}] " if ts else ""
+    return f"{prefix}{event['from']}\n  {event['body']}\n"
+
+
+def format_json_line(event):
+    """Format one event as one JSON Lines record."""
+    return json.dumps(event, ensure_ascii=False)

--- a/test/listen_output.py
+++ b/test/listen_output.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests for listen output formatting helpers."""
+
+import json
+import sys
+from pathlib import Path
+
+repo = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo / "lib"))
+
+from output import format_json_line, format_listen_human, listen_event
+
+
+def test_json_line_preserves_multiline_body():
+    event = listen_event(
+        {
+            "from": "+15551234567@cheogram.com",
+            "to": "agent@xmpp.chat",
+            "body": "Hi Quick!\n\nParent situation:\nMy kid refuses the shower.",
+        },
+        timestamp="2026-06-20T17:34:54+00:00",
+    )
+    line = format_json_line(event)
+    parsed = json.loads(line)
+
+    assert parsed == {
+        "from": "+15551234567@cheogram.com",
+        "to": "agent@xmpp.chat",
+        "body": "Hi Quick!\n\nParent situation:\nMy kid refuses the shower.",
+        "timestamp": "2026-06-20T17:34:54+00:00",
+    }
+    assert "\n" not in line
+
+
+def test_human_output_matches_legacy_shape_without_timestamp():
+    event = listen_event(
+        {
+            "from": "+15551234567@cheogram.com",
+            "to": "agent@xmpp.chat",
+            "body": "hello",
+        }
+    )
+
+    assert format_listen_human(event) == "+15551234567@cheogram.com\n  hello\n"
+
+
+if __name__ == "__main__":
+    test_json_line_preserves_multiline_body()
+    test_human_output_matches_legacy_shape_without_timestamp()
+    print("listen output tests passed")

--- a/test/sms.bats
+++ b/test/sms.bats
@@ -31,3 +31,16 @@ setup() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"SMS_JID and SMS_PASSWORD must be set"* ]]
 }
+
+@test "listen: fails without credentials" {
+  unset SMS_JID SMS_PASSWORD
+  run sms listen
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SMS_JID and SMS_PASSWORD must be set"* ]]
+}
+
+@test "listen: JSON Lines formatting preserves multiline bodies" {
+  run python3 "$REPO_DIR/test/listen_output.py"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"listen output tests passed"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a machine-readable mode for live SMS streams:

- `sms listen --json` now emits one JSON object per inbound message (JSON Lines)
- JSON output preserves multiline SMS bodies inside the `body` string instead of relying on human formatting
- human-readable `sms listen` output remains the default
- adds pure formatting helpers and regressions for multiline JSONL output
- refreshes generated README docs/test count

Closes #6.

## Validation

- `bash -n .mise/tasks/test test/test_helper.bash`
- `python3 -m py_compile lib/xmpp.py lib/output.py test/listen_output.py .mise/tasks/archive/enable .mise/tasks/archive/status .mise/tasks/contact/add .mise/tasks/contact/list .mise/tasks/listen .mise/tasks/read .mise/tasks/send .mise/tasks/wait .mise/tasks/welcome`
- `mise run test --filter listen`
- `mise run test`
- `codebase lint "$PWD"`
- `readme build --check`
- `git diff --check HEAD~1..HEAD`

## Notes

This came from the live SMS/NVR cockpit test: parsing human `sms listen` output dropped multiline parent-question content. JSONL gives downstream session monitors a stable boundary without changing the default human stream.
