### PR TITLE
Keep listen JSON stdout machine-readable

### DIFF
--- a/.mise/tasks/listen
+++ b/.mise/tasks/listen
@@ -34,4 +34,4 @@ def on_message(msg):
         print(format_listen_human(event), flush=True)
 
 
-asyncio.run(listen_messages(jid, password, callback=on_message, timeout=timeout))
+asyncio.run(listen_messages(jid, password, callback=on_message, timeout=timeout, announce=not as_json))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Send and receive SMS through [JMP.chat](https://jmp.chat), which bridges SMS to 
 ![protocol: XMPP](https://img.shields.io/badge/protocol-XMPP-blue?style=flat)
 [![bridge: JMP.chat](https://img.shields.io/badge/bridge-JMP.chat-7c3aed?style=flat)](https://jmp.chat)
 [![library: slixmpp](https://img.shields.io/badge/library-slixmpp-3776AB?style=flat&logo=python&logoColor=white)](https://slixmpp.readthedocs.io)
-![tests: 6 passing](https://img.shields.io/badge/tests-6%20passing-brightgreen?style=flat)
+![tests: 7 passing](https://img.shields.io/badge/tests-7%20passing-brightgreen?style=flat)
 ![lints: 9](https://img.shields.io/badge/lints-9-blue?style=flat)
 ![README: TSX](https://img.shields.io/badge/README-TSX-f472b6?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
@@ -177,7 +177,7 @@ readme build --check
 git diff --check
 ```
 
-6 tests using [BATS](https://github.com/bats-core/bats-core). The default test suite validates task structure and error handling without requiring live XMPP credentials. See [CONTRIBUTING.md](CONTRIBUTING.md) for local workflow and live-network boundaries.
+7 tests using [BATS](https://github.com/bats-core/bats-core). The default test suite validates task structure and error handling without requiring live XMPP credentials. See [CONTRIBUTING.md](CONTRIBUTING.md) for local workflow and live-network boundaries.
 
 <br />
 

--- a/lib/xmpp.py
+++ b/lib/xmpp.py
@@ -199,7 +199,7 @@ async def add_contact(jid, password, contact_jid):
     return result
 
 
-async def listen_messages(jid, password, callback, timeout=60):
+async def listen_messages(jid, password, callback, timeout=60, announce=True):
     """Connect and listen for incoming messages in real-time."""
     client = SMSClient(jid, password)
 
@@ -216,7 +216,8 @@ async def listen_messages(jid, password, callback, timeout=60):
     async def on_session_start(event):
         client.send_presence()
         await client.get_roster()
-        print(f"Listening ({timeout}s)..." if timeout else "Listening...", flush=True)
+        if announce:
+            print(f"Listening ({timeout}s)..." if timeout else "Listening...", flush=True)
 
     client.add_event_handler("session_start", on_session_start)
 

--- a/test/listen_task.py
+++ b/test/listen_task.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for the listen task wrapper without a live XMPP connection."""
+
+import contextlib
+import io
+import json
+import os
+import runpy
+import sys
+import types
+from pathlib import Path
+
+repo = Path(__file__).resolve().parents[1]
+task_path = repo / ".mise" / "tasks" / "listen"
+
+
+async def fake_listen_messages(jid, password, callback, timeout=60, announce=True):
+    if announce:
+        print(f"Listening ({timeout}s)..." if timeout else "Listening...")
+    callback(
+        {
+            "from": "+15551234567@cheogram.com",
+            "to": "agent@xmpp.chat",
+            "body": "hello\nsecond line",
+        }
+    )
+
+
+def run_listen_task(*, as_json: bool) -> str:
+    fake_xmpp = types.ModuleType("xmpp")
+    fake_xmpp.listen_messages = fake_listen_messages
+
+    old_env = os.environ.copy()
+    old_xmpp = sys.modules.get("xmpp")
+    old_argv = sys.argv[:]
+    output = io.StringIO()
+    try:
+        os.environ.update(
+            {
+                "MISE_CONFIG_ROOT": str(repo),
+                "SMS_JID": "agent@xmpp.chat",
+                "SMS_PASSWORD": "fake-password",
+                "usage_timeout": "0",
+                "usage_json": "true" if as_json else "false",
+            }
+        )
+        sys.modules["xmpp"] = fake_xmpp
+        sys.argv = [str(task_path)]
+        with contextlib.redirect_stdout(output):
+            runpy.run_path(str(task_path), run_name="__sms_listen_task_test__")
+        return output.getvalue()
+    finally:
+        os.environ.clear()
+        os.environ.update(old_env)
+        sys.argv = old_argv
+        if old_xmpp is None:
+            sys.modules.pop("xmpp", None)
+        else:
+            sys.modules["xmpp"] = old_xmpp
+
+
+def test_json_mode_stdout_is_json_lines_only():
+    output = run_listen_task(as_json=True)
+    lines = output.splitlines()
+
+    assert len(lines) == 1
+    assert "Listening" not in output
+    event = json.loads(lines[0])
+    assert event["from"] == "+15551234567@cheogram.com"
+    assert event["body"] == "hello\nsecond line"
+
+
+def test_human_mode_keeps_startup_banner():
+    output = run_listen_task(as_json=False)
+
+    assert output.startswith("Listening...\n")
+    assert "+15551234567@cheogram.com\n  hello\nsecond line\n" in output
+
+
+if __name__ == "__main__":
+    test_json_mode_stdout_is_json_lines_only()
+    test_human_mode_keeps_startup_banner()
+    print("listen task tests passed")

--- a/test/sms.bats
+++ b/test/sms.bats
@@ -44,3 +44,9 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"listen output tests passed"* ]]
 }
+
+@test "listen: JSON mode stdout contains JSON Lines only" {
+  run python3 "$REPO_DIR/test/listen_task.py"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"listen task tests passed"* ]]
+}


### PR DESCRIPTION
## Summary

- keep `sms listen --json` stdout machine-readable by suppressing the human `Listening...` banner in JSON mode
- preserve the banner in default human mode
- add a task-level fake-listener regression proving JSON mode stdout contains only JSON Lines

## Validation

- `bash -n .mise/tasks/test test/test_helper.bash`
- `python3 -m py_compile lib/xmpp.py lib/output.py .mise/tasks/listen test/listen_output.py test/listen_task.py`
- `mise run test --filter listen`
- `mise run test`
- `codebase lint "$PWD"`
- `readme build --check`
- `git diff --check`

## Review note

This should receive adversarial review before merge. The change is small, but it affects a machine-readable live stream used by the SMS cockpit work.
